### PR TITLE
Swap naming for EG2 Peanut PR Swirl cases

### DIFF
--- a/scripts/algsinfo.js
+++ b/scripts/algsinfo.js
@@ -2198,7 +2198,7 @@ var algsInfo = {
         "s": "U' R U' B L' B' R'"
     },
     "228": {
-        "name": "EG2 Peanut BR + S1",
+        "name": "EG2 Peanut BR + S2",
         "a": [
             "x' r' B' r B r' R' r R r R'",
             "x z2 R' r' R r R b' R b R' b'"
@@ -2206,7 +2206,7 @@ var algsInfo = {
         "s": "R B L' R' U' R U B' R' U"
     },
     "229": {
-        "name": "EG2 Peanut BR + S2",
+        "name": "EG2 Peanut BR + S1",
         "a": [
             "y' z' r B R' B' R r R' b' B r'",
             "x z' R r R' B R B R r' R B"


### PR DESCRIPTION
The naming of these two cases are swapped. Can be verified at the [EG2 sheet](https://docs.google.com/spreadsheets/d/1wlNP1AxmvjXFfgI5Rckrpf9004byL5UKILvYCS4dFvc/edit?gid=2099481178#gid=2099481178)